### PR TITLE
make fast the default pitch correction method

### DIFF
--- a/ConvertFiles.py
+++ b/ConvertFiles.py
@@ -51,7 +51,7 @@ logging.basicConfig(
 )
 logger = logging.getLogger(__name__)
 
-def convert_files(dirs_to_convert, output_type=NEW, pitch_correction_method=SLOW):
+def convert_files(dirs_to_convert, output_type=NEW, pitch_correction_method=FAST):
 
     DLCID = DLCID_2022 if output_type == OLD else DLCID_2025
 
@@ -172,8 +172,8 @@ def convert_files(dirs_to_convert, output_type=NEW, pitch_correction_method=SLOW
 
             # generating vxla file
             if pitch_correction_method == SLOW:
-                pitch_corr = PitchAnalyzer.get_pitch_correction_suggestion(txt_data, os.fspath(list_in_dir / ogg_file_name),
-                                                                              min_pitch=PITCH_MIN, max_pitch=PITCH_MAX)
+                pitch_corr = PitchAnalyzer.get_pitch_correction_suggestion_slow(txt_data, os.fspath(list_in_dir / ogg_file_name),
+                                                                                min_pitch=PITCH_MIN, max_pitch=PITCH_MAX)
             else:
                 pitch_corr = PitchAnalyzer.get_pitch_correction_suggestion_fast(txt_data,min_pitch=PITCH_MIN, max_pitch=PITCH_MAX)
             UltrastarToSingit.main(files_txt[-1], song_duration, pitch_corr, s=name_id, dir=list_in_dir, output_type=output_type)
@@ -563,7 +563,7 @@ def delete_patch_folder():
     except Exception as e:
         tqdm.write(f"Error deleting Patch folder: {e}")
 
-def main(output_type=NEW, pitch_correction_method=SLOW):
+def main(output_type=NEW, pitch_correction_method=FAST):
     delete_patch_folder()
     dirs_to_convert = find_folders_to_convert()
 
@@ -578,10 +578,10 @@ if __name__ == '__main__':
     parser.add_argument('output_type', nargs='?', type=str, default=NEW, choices=[OLD, NEW],
                         help='Output file type: old or new (default: new)')
     parser.add_argument('pitch_correction_method', nargs='?',
-                        type=str.lower, default=SLOW, choices=[FAST, SLOW],
+                        type=str.lower, default=FAST, choices=[FAST, SLOW],
                         help='Which pitch correction method to use: '
                              '[fast] - using simple calculations '
-                             '[slow] - using audio analyzer (default: slow)')
+                             '[slow] - using audio analyzer (default: fast)')
 
     args = parser.parse_args()
 

--- a/PitchAnalyzer.py
+++ b/PitchAnalyzer.py
@@ -1,9 +1,7 @@
-import librosa
 import numpy as np
-import crepe
 from tqdm import tqdm
 
-def get_pitch_correction_suggestion(txt_data, audio_file, min_pitch, max_pitch):
+def get_pitch_correction_suggestion_slow(txt_data, audio_file, min_pitch, max_pitch):
 
     pitch_from_txt = get_txt_pitch_values(txt_data)
 
@@ -58,6 +56,9 @@ def get_audio_pitch_values(audio_file):
     }
 
 def analyze_pitch_from_audio(audio_file):
+    import librosa
+    import crepe
+
     y, sr = librosa.load(audio_file, sr=16000)
     time, frequency, confidence, activation = crepe.predict(y, sr, viterbi=True, model_capacity='tiny')
     frequency[confidence < 0.9] = np.nan

--- a/README.md
+++ b/README.md
@@ -20,10 +20,11 @@ After successfully adding over 400 songs to Let’s Sing! 2022, I expanded suppo
 - Python modules used: 
   - pandas (2.2.3)
   - tqdm (4.67.1)
-  - librosa (0.11.0)
-  - crepe (0.0.16)
-  - intel_tensorflow (2.91.1)
-  - numpy (1.23.5 - low due to intel_tensorflow compatibility, higher version is possible with generic version of tensorflow)
+  - numpy (1.23.5) - low due to intel_tensorflow compatibility, higher version is possible with generic version of tensorflow
+  - needed only for the slower (more accurate?) pitch correction:
+    - librosa (0.11.0)
+    - crepe (0.0.16)
+    - intel_tensorflow (2.91.1)
 
 ## Usage
 0. Install Let's Sing! 2022 or 2025 to your console and install one DLC song pack, note your COREID and DLCID values.
@@ -34,7 +35,7 @@ After successfully adding over 400 songs to Let’s Sing! 2022, I expanded suppo
 3. Adjust the convertFiles.py script if needed, i.e. change the **COREID** and/or **DLCID** presets at the top to match your installed Let's Sing! ROM and DLC. These are set by default:
    - for Let's Sing! **2022**, COREID = 0100CC30149B8000, DLCID = 0100CC30149B9011
    - for Let's Sing! **2025**, DLC_NAME = songs_fr, DLCID = 01001C101ED11002
-4. Run the converter from the command line ('2025' is the default output type, 'slow' is the default pitch correction method):
+4. Run the converter from the command line ('2025' is the default output type, 'fast' is the default pitch correction method):
 ```
 ConvertFiles.py [2022|2025] [fast|slow]
 ```


### PR DESCRIPTION
Tried not to force the slower method by default and hopefully made it so it's possible to run the script without having tensorflow, librosa and crepe installed